### PR TITLE
Add support for service groups to nrpe role

### DIFF
--- a/nrpe-external-master/defaults/main.yaml
+++ b/nrpe-external-master/defaults/main.yaml
@@ -3,3 +3,4 @@ service_context: juju
 unit_name: "{{ local_unit | replace('/', '-') }}"
 plugin_dir: /usr/lib/nagios/plugins
 service_description:
+service_groups: "{{ service_context }}"

--- a/nrpe-external-master/templates/check_name_service_export.cfg.jinja2
+++ b/nrpe-external-master/templates/check_name_service_export.cfg.jinja2
@@ -6,5 +6,5 @@ define service {
     host_name                       {{ service_context }}-{{ unit_name }}
     service_description             {{ service_description }}
     check_command                   check_nrpe!{{ check_name }}
-    servicegroups                   {{ service_context }}
+    servicegroups                   {{ service_groups }}
 }


### PR DESCRIPTION
Add support for specifying nagios service groups, for better alert targeting.

As per https://code.launchpad.net/~chris-gondolin/charm-helpers/add-nagios-servicegroups-support/+merge/230657
