### PR TITLE
Make the nagios service config pick up config changes

### DIFF
--- a/nrpe-external-master/tasks/main.yaml
+++ b/nrpe-external-master/tasks/main.yaml
@@ -8,6 +8,7 @@
     owner: nagios
     group: nagios
     mode: 0644
+  when: relations['nrpe-external-master']
   notify:
     - nrpe config changes
 
@@ -15,11 +16,13 @@
   tags:
     - nrpe-external-master-relation-changed
     - upgrade-charm
+    - config-changed
   template:
     src: "check_name_service_export.cfg.jinja2"
-    dest: "/var/lib/nagios/export/service__{{ service_context }}-{{ unit_name }}_{{ check_name }}.cfg"
+    dest: "/var/lib/nagios/export/service__{{ unit_name }}_{{ check_name }}.cfg"
     owner: nagios
     group: nagios
     mode: 0644
+  when: relations['nrpe-external-master']
   notify:
     - nrpe config changes


### PR DESCRIPTION
This change links the nagios templating tasks into config-changed, so nagios_context changes are written properly. To make it easier, also drops the sevice_context from the path, to save awkward cleaning up of old files when the context changes.
