### PR TITLE
Nrpe checks loop

### DIFF
--- a/nrpe-external-master/defaults/main.yaml
+++ b/nrpe-external-master/defaults/main.yaml
@@ -6,4 +6,4 @@ service_description:
 service_groups: "{{ service_context }}"
 checks:
   - name: "{{ check_name }}"
-  - params: "{{ check_params }}"
+    params: "{{ check_params }}"

--- a/nrpe-external-master/defaults/main.yaml
+++ b/nrpe-external-master/defaults/main.yaml
@@ -4,3 +4,6 @@ unit_name: "{{ local_unit | replace('/', '-') }}"
 plugin_dir: /usr/lib/nagios/plugins
 service_description:
 service_groups: "{{ service_context }}"
+checks:
+  - name: "{{ check_name }}"
+  - params: "{{ check_params }}"

--- a/nrpe-external-master/tasks/main.yaml
+++ b/nrpe-external-master/tasks/main.yaml
@@ -4,11 +4,12 @@
     - upgrade-charm
   template:
     src: "check_name.cfg.jinja2"
-    dest: "/etc/nagios/nrpe.d/{{ check_name }}.cfg"
+    dest: "/etc/nagios/nrpe.d/{{ item.name }}.cfg"
     owner: nagios
     group: nagios
     mode: 0644
   when: relations['nrpe-external-master']
+  with_items: checks
   notify:
     - nrpe config changes
 

--- a/nrpe-external-master/templates/check_name.cfg.jinja2
+++ b/nrpe-external-master/templates/check_name.cfg.jinja2
@@ -1,4 +1,4 @@
 #---------------------------------------------------
 # This file is Juju managed
 #---------------------------------------------------
-command[{{ item.name }}]={{ plugin_dir }}/{{ check_name }} {{ item.params }}
+command[{{ item.name }}]={{ plugin_dir }}/{{ item.name }} {{ item.params }}

--- a/nrpe-external-master/templates/check_name.cfg.jinja2
+++ b/nrpe-external-master/templates/check_name.cfg.jinja2
@@ -1,4 +1,4 @@
 #---------------------------------------------------
 # This file is Juju managed
 #---------------------------------------------------
-command[{{ check_name }}]={{ plugin_dir }}/{{ check_name }} {{ check_params }}
+command[{{ item.name }}]={{ plugin_dir }}/{{ check_name }} {{ item.params }}


### PR DESCRIPTION
This allows the checks to be programmatically generated from the calling playbook, as the `with_items` syntax was deprecated and subsequently removed around 1.5/1.6.