### PR TITLE
Allow checks list to be used to generate service definition config file

### DIFF
--- a/nrpe-external-master/tasks/main.yaml
+++ b/nrpe-external-master/tasks/main.yaml
@@ -20,10 +20,11 @@
     - config-changed
   template:
     src: "check_name_service_export.cfg.jinja2"
-    dest: "/var/lib/nagios/export/service__{{ unit_name }}_{{ check_name }}.cfg"
+    dest: "/var/lib/nagios/export/service__{{ unit_name }}_{{ item.name }}.cfg"
     owner: nagios
     group: nagios
     mode: 0644
   when: relations['nrpe-external-master']
+  with_items: checks
   notify:
     - nrpe config changes

--- a/nrpe-external-master/templates/check_name_service_export.cfg.jinja2
+++ b/nrpe-external-master/templates/check_name_service_export.cfg.jinja2
@@ -6,6 +6,6 @@ define service {
     use                             active-service
     host_name                       {{ nrpe_relation['nagios_hostname'] | default(unit_name) }}
     service_description             {{ service_description }}
-    check_command                   check_nrpe!{{ check_name }}
+    check_command                   check_nrpe!{{ item.name }}
     servicegroups                   {{ service_groups if service_groups else service_context }}
 }


### PR DESCRIPTION
This should have been part of #10, without it you can generate the check command file(s) but the definition file(s) gets missed off.