### PR TITLE
Make wsgi-app log retention parameters tunable and increase retention…

### DIFF
--- a/wsgi-app/defaults/main.yaml
+++ b/wsgi-app/defaults/main.yaml
@@ -7,3 +7,5 @@ access_log: "{{ log_dir }}/{{ service_name }}-access.log"
 error_log: "{{ log_dir }}/{{ service_name }}-error.log"
 extra_logs: ""
 gunicorn_path: "gunicorn"
+log_rotation_frequency: "daily"
+logs_to_keep: 729

--- a/wsgi-app/templates/log-rotate.j2
+++ b/wsgi-app/templates/log-rotate.j2
@@ -1,7 +1,7 @@
 {{ access_log }} {{ error_log }} {{ extra_logs }} {
-    daily
+    {{log_rotation_frequency}}
     su root {{ wsgi_group }}
-    rotate 60
+    rotate {{logs_to_keep}}
     missingok
     notifempty
     compress


### PR DESCRIPTION
… to 24 months.

The new defaults are meant to comply with policy requirements to keep
logs at least 12 months but not more than 24 months. The rotation
frequency and number of logs to keep can be tuned according to other
needs.