### PR TITLE
Pass list ont string to with_items

### DIFF
--- a/payload/tasks/main.yaml
+++ b/payload/tasks/main.yaml
@@ -170,4 +170,4 @@
   file:
     path: "{{ item }}"
     state: absent
-  with_items: "{{ old_payloads.stdout_lines }}"
+  with_items: old_payloads.stdout_lines


### PR DESCRIPTION
Without this change, ansible errors for me with: 

TASK: [payload | Remove any old payloads] ************************************* 
fatal: [localhost] => with_items expects a list or a set

FATAL: all hosts have already failed -- aborting


This fix seems correct, and seems to work for me (although I havn't got old payloads to clean up)