### PR TITLE
Allow dev setup

### DIFF
--- a/directories-and-permissions/handlers/main.yaml
+++ b/directories-and-permissions/handlers/main.yaml
@@ -1,6 +1,6 @@
 # ansible file module's recursion seems broken
 - name: Ensure group ownership
-  shell: chown -R root:{{ user }} {{ item }}
+  shell: chown -R :{{ user }} {{ item }}
   with_items: readonly_dirs + writable_dirs
 
 - name: Ensure readonly group permissions

--- a/directories-and-permissions/tasks/main.yaml
+++ b/directories-and-permissions/tasks/main.yaml
@@ -15,7 +15,7 @@
     - install
     - upgrade-charm
     - config-changed
-  file: path={{ item }} state=directory group={{ user }}
+  command: mkdir -p {{ item }}
   with_items: readonly_dirs + writable_dirs 
 
 - name: Force permissions

--- a/payload/files/payloads-to-remove.py
+++ b/payload/files/payloads-to-remove.py
@@ -23,7 +23,7 @@ if args.archives_dir is None:
     args.archives_dir = os.path.join(args.payload_dir, 'archives')
 
 
-current_dir = os.path.realpath(os.path.join(args.payload_dir, 'current'))
+current_dir = os.path.realpath(os.path.join(args.payload_dir, 'latest'))
 
 
 def verify_directories(args):

--- a/payload/files/payloads-to-remove.py
+++ b/payload/files/payloads-to-remove.py
@@ -23,7 +23,7 @@ if args.archives_dir is None:
     args.archives_dir = os.path.join(args.payload_dir, 'archives')
 
 
-current_dir = os.path.realpath(os.path.join(args.payload_dir, 'latest'))
+current_dir = os.path.realpath(os.path.join(args.payload_dir, 'current'))
 
 
 def verify_directories(args):

--- a/payload/tasks/main.yaml
+++ b/payload/tasks/main.yaml
@@ -158,20 +158,13 @@
     msg: "The configured current_symlink does not exist, {{ payload_dir }}/{{ current_symlink }}"
   when: stat_current_symlink.stat.exists == False
 
-- name: Check whether live symlink exists
-  tags:
-    - config-changed
-    - preload
-  stat: path={{ payload_dir }}/current
-  register: stat_live_symlink
-
 - name: Check for any old payloads to remove
   tags:
     - config-changed
     - preload
   script: payloads-to-remove.py {{ payload_dir }}
   register: old_payloads
-  when: stat_live_symlink.stat.exists
+  when: stat_current_symlink.stat.exists
 
 - name: Remove any old payloads
   tags:
@@ -181,4 +174,4 @@
     path: "{{ item }}"
     state: absent
   with_items: old_payloads.stdout_lines
-  when: stat_live_symlink.stat.exists
+  when: stat_current_symlink.stat.exists

--- a/payload/tasks/main.yaml
+++ b/payload/tasks/main.yaml
@@ -147,6 +147,7 @@
 - name: Check whether the set current symlink exists.
   tags:
     - config-changed
+    - preload
   stat: path={{ payload_dir }}/{{ current_symlink }}
   register: stat_current_symlink
 
@@ -157,12 +158,20 @@
     msg: "The configured current_symlink does not exist, {{ payload_dir }}/{{ current_symlink }}"
   when: stat_current_symlink.stat.exists == False
 
+- name: Check whether live symlink exists
+  tags:
+    - config-changed
+    - preload
+  stat: path={{ payload_dir }}/current
+  register: stat_live_symlink
+
 - name: Check for any old payloads to remove
   tags:
     - config-changed
     - preload
   script: payloads-to-remove.py {{ payload_dir }}
   register: old_payloads
+  when: stat_live_symlink.stat.exists
 
 - name: Remove any old payloads
   tags:
@@ -172,3 +181,4 @@
     path: "{{ item }}"
     state: absent
   with_items: old_payloads.stdout_lines
+  when: stat_live_symlink.stat.exists

--- a/payload/tasks/main.yaml
+++ b/payload/tasks/main.yaml
@@ -116,6 +116,7 @@
     path: "{{ current_payload_dir }}" 
     state: directory
     group: "{{ group }}"
+  when: already_extracted.stat.exists == False
 
 - name: Extract payload.
   tags:

--- a/wsgi-app/defaults/main.yaml
+++ b/wsgi-app/defaults/main.yaml
@@ -2,9 +2,11 @@ python_path: ""
 current_symlink: latest
 listen_port: 8081
 env_extra: ""
-wsgi_extra: ""
+wsgi_extra_config: ""
 access_log: "{{ log_dir }}/{{ service_name }}-access.log"
 error_log: "{{ log_dir }}/{{ service_name }}-error.log"
+# support older gunicorn charm which didn't have wsgi_error_logfile or wsgi_extra_config
+wsgi_extra: "{{ '' if wsgi_extra_config else '--error-logfile=' + error_log }} {{ wsgi_extra }}"
 extra_logs: ""
 gunicorn_path: "gunicorn"
 log_rotation_frequency: "daily"

--- a/wsgi-app/tasks/main.yaml
+++ b/wsgi-app/tasks/main.yaml
@@ -9,9 +9,11 @@
     wsgi_user={{ wsgi_user }}
     wsgi_group={{ wsgi_group }}
     port={{ listen_port }}
-    wsgi_access_logfile={{ access_log }}
+    wsgi_access_logfile="{{ access_log }}"
+    wsgi_error_logfile="{{ error_log }}"
     wsgi_wsgi_file={{ wsgi_application }}
-    wsgi_extra="--error-logfile={{ error_log }} {{ wsgi_extra }}"
+    wsgi_extra="{{ wsgi_extra }}"
+    wsgi_extra_config="{{ wsgi_extra_config }}"
     env_extra="{{ env_extra }}"
     gunicorn_path="{{ gunicorn_path }}"
     timestamp={{ ansible_date_time.iso8601_micro }}


### PR DESCRIPTION
 - don't hardcode owner, or else breaks dev setup
 - use mkdir -p rather than file: state=directory, as the later fails on a symlink, but the former is fine.
 - update to handle new gunicorn charm
 - some more when: protection for the dev scenario