### PR TITLE
Use os.readlink not os.path.realpath

### DIFF
--- a/payload/files/payloads-to-remove.py
+++ b/payload/files/payloads-to-remove.py
@@ -23,7 +23,7 @@ if args.archives_dir is None:
     args.archives_dir = os.path.join(args.payload_dir, 'archives')
 
 
-current_dir = os.path.realpath(os.path.join(args.payload_dir, 'latest'))
+current_dir = os.readlink(os.path.join(args.payload_dir, 'latest'))
 
 
 def verify_directories(args):


### PR DESCRIPTION
Normally, we have single level symlinks in the code dir

e.g.

latest -> ./r1234

In a development setup, build_label is devel, which is symlinked to an out-of tree dir. like so:

latest -> ./devel -> /home/user/somedir

os.path.realpath recurses down symlinks, so current_dir ends up as "/home/user/somedir", and current_label as "somedir" which of course is not present in the code dir.

I have modified instead to use os.readlink, which only follows one symlink level, which seems like a sensible choice here, as we always expect latest to point to something in the same dir.